### PR TITLE
fix: the multiplication (size_t)num_exts_i * (sizeof... in glad.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,42 @@ cd ./baregl
 ./gen_proj_linux.sh
 ```
 
+## CMake Quick Start
+Create a new C++ project with `glfw`, `glm`, and `baregl` in a few seconds with this quick start `CMakeLists.txt`.
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(my-project)
+
+set(TARGET_NAME ${PROJECT_NAME})
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+
+set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_DOCS  OFF CACHE BOOL "" FORCE)
+set(GLFW_INSTALL     OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(glfw GIT_REPOSITORY https://github.com/glfw/glfw.git GIT_TAG 3.4)
+
+set(GLM_BUILD_TESTS   OFF CACHE BOOL "" FORCE)
+set(GLM_ENABLE_CXX_20 ON  CACHE BOOL "" FORCE)
+FetchContent_Declare(glm GIT_REPOSITORY https://github.com/g-truc/glm.git GIT_TAG 1.0.1)
+
+FetchContent_Declare(baregl GIT_REPOSITORY https://github.com/adriengivry/baregl.git GIT_TAG origin/main)
+
+FetchContent_MakeAvailable(glfw glm baregl)
+
+file(GLOB_RECURSE SOURCES "*.cpp" "*.h")
+add_executable(${TARGET_NAME} ${SOURCES})
+
+target_link_libraries(my-project PRIVATE glfw glm baregl)
+```
+
+> [!NOTE]
+> Want a hello world triangle? Add this file alongside your `CMakeLists.txt`:
+> [examples/1-triangle/Main.cpp](examples/1-triangle/Main.cpp)
+
 ## Contributing
 All contributions to *BareGL* are welcome — whether it's reporting bugs, suggesting new features, or submitting code improvements.
 

--- a/src/baregl/detail/glad/glad.c
+++ b/src/baregl/detail/glad/glad.c
@@ -181,7 +181,7 @@ static int get_exts(void) {
         num_exts_i = 0;
         glGetIntegerv(GL_NUM_EXTENSIONS, &num_exts_i);
         if (num_exts_i > 0) {
-            exts_i = (char **)malloc((size_t)num_exts_i * (sizeof *exts_i));
+            exts_i = (char **)calloc(num_exts_i, sizeof *exts_i);
         }
 
         if (exts_i == NULL) {
@@ -192,7 +192,7 @@ static int get_exts(void) {
             const char *gl_str_tmp = (const char*)glGetStringi(GL_EXTENSIONS, index);
             size_t len = strlen(gl_str_tmp);
 
-            char *local_str = (char*)malloc((len+1) * sizeof(char));
+            char *local_str = (char*)calloc(len+1, sizeof(char));
             if(local_str != NULL) {
                 memcpy(local_str, gl_str_tmp, (len+1) * sizeof(char));
             }


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/baregl/detail/glad/glad.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `src/baregl/detail/glad/glad.c:184` |
| **CWE** | CWE-190 |

**Description**: The multiplication (size_t)num_exts_i * (sizeof *exts_i) at line 184 can overflow on 32-bit systems where size_t is 32 bits. Since sizeof(char*) is 4 bytes on 32-bit systems, any num_exts_i value greater than 1,073,741,823 causes integer overflow, resulting in a drastically undersized allocation. Subsequent writes to this buffer during extension parsing corrupt heap memory.

## Changes
- `src/baregl/detail/glad/glad.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
