### PR TITLE
Fixed POLYGON_MODE return type

### DIFF
--- a/include/baregl/data/GetResult.h
+++ b/include/baregl/data/GetResult.h
@@ -30,6 +30,7 @@
 #include <baregl/types/EPixelDataType.h>
 #include <baregl/types/EOperation.h>
 #include <baregl/types/EProvokingVertexConvention.h>
+#include <baregl/types/ERasterizationMode.h>
 
 namespace baregl::data
 {

--- a/include/baregl/data/GetResultList.h
+++ b/include/baregl/data/GetResultList.h
@@ -47,7 +47,7 @@
 	X(CULL_FACE_MODE, int, baregl::data::FixedCount<1>, NOT_INDEXED, types::ECullFace) \
 	X(FRONT_FACE, int, baregl::data::FixedCount<1>, NOT_INDEXED, int) \
 	X(POLYGON_SMOOTH, bool, baregl::data::FixedCount<1>, NOT_INDEXED, bool) \
-	X(POLYGON_MODE, int, baregl::data::FixedCount<2>, NOT_INDEXED, int) \
+	X(POLYGON_MODE, int, baregl::data::FixedCount<2>, NOT_INDEXED, types::ERasterizationMode) \
 	X(POLYGON_OFFSET_FACTOR, float, baregl::data::FixedCount<1>, NOT_INDEXED, float) \
 	X(POLYGON_OFFSET_UNITS, float, baregl::data::FixedCount<1>, NOT_INDEXED, float) \
 	X(POLYGON_OFFSET_POINT, bool, baregl::data::FixedCount<1>, NOT_INDEXED, bool) \

--- a/tests/suites/Context.cpp
+++ b/tests/suites/Context.cpp
@@ -101,7 +101,7 @@ TEST_CASE( "Context::Get return the expected values", "[context]" ) {
 		REQUIRE( GET(CULL_FACE_MODE) == ECullFace::FRONT_AND_BACK );
 		REQUIRE( GET_WORKS(FRONT_FACE) );
 		REQUIRE( GET(POLYGON_SMOOTH) == false ); // TODO: How do we enable that??
-		REQUIRE( GET_WORKS(POLYGON_MODE) );
+		REQUIRE( GET(POLYGON_MODE) == ERasterizationMode::FILL );
 		REQUIRE( GET(POLYGON_OFFSET_FACTOR) == 0.0f );
 		REQUIRE( GET(POLYGON_OFFSET_UNITS) == 0.0f );
 		REQUIRE( GET(POLYGON_OFFSET_POINT) == false );


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
`Context::Get<EGetParameter::POLYGON_MODE>()` return type was `int` instead of `ERasterizationMode`.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #(issue number)

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
