### PR TITLE
Implemented unique texture index generation for samplers and images

### DIFF
--- a/include/baregl/data/UniformInfo.h
+++ b/include/baregl/data/UniformInfo.h
@@ -10,6 +10,7 @@
 
 #include <any>
 #include <string>
+#include <optional>
 
 namespace baregl::data
 {
@@ -21,5 +22,6 @@ namespace baregl::data
 		types::EUniformType type;
 		std::string name;
 		std::any defaultValue;
+		std::optional<uint32_t> textureIndex;
 	};
 }

--- a/src/baregl/ShaderProgram.cpp
+++ b/src/baregl/ShaderProgram.cpp
@@ -161,6 +161,8 @@ void ShaderProgram::SetUniform<type>(const std::string& p_name, const type& valu
 		GLint activeUniformCount = 0;
 		glGetProgramiv(m_id, GL_ACTIVE_UNIFORMS, &activeUniformCount);
 
+		uint32_t textureIndex = 0U;
+
 		for (GLint i = 0; i < activeUniformCount; ++i)
 		{
 			GLint arraySize = 0;
@@ -195,9 +197,17 @@ void ShaderProgram::SetUniform<type>(const std::string& p_name, const type& valu
 				case FLOAT_MAT4: return GetUniform<math::Mat4>(name);
 				case SAMPLER_2D: return std::make_any<Texture*>(nullptr);
 				case SAMPLER_CUBE: return std::make_any<Texture*>(nullptr);
+				case IMAGE_2D: return std::make_any<Texture*>(nullptr);
+				case IMAGE_CUBE: return std::make_any<Texture*>(nullptr);
 				default: return std::nullopt;
 				}
 			}();
+
+			const bool isTexture =
+				uniformType == types::EUniformType::SAMPLER_2D ||
+				uniformType == types::EUniformType::SAMPLER_CUBE ||
+				uniformType == types::EUniformType::IMAGE_2D ||
+				uniformType == types::EUniformType::IMAGE_CUBE;
 
 			// Only add the uniform if it has a value (unsupported uniform types will be ignored)
 			if (uniformValue.has_value())
@@ -205,7 +215,8 @@ void ShaderProgram::SetUniform<type>(const std::string& p_name, const type& valu
 				m_uniforms.emplace(name, data::UniformInfo{
 					.type = uniformType,
 					.name = name,
-					.defaultValue = uniformValue
+					.defaultValue = uniformValue,
+					.textureIndex = isTexture ? std::make_optional(textureIndex++) : std::nullopt
 				});
 			}
 		}


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
This ensures sampler & image uniforms have a unique ready to use index that can be used when binding. This can help prevent texture index overlapping.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #(issue number)

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
