### PR TITLE
Cleaned up initial OpenGL state on context creation

### DIFF
--- a/src/baregl/Context.cpp
+++ b/src/baregl/Context.cpp
@@ -302,10 +302,6 @@ namespace baregl
 			glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
 			glDebugMessageCallback(GLDebugMessageCallback, nullptr);
 		}
-
-		// Seamless cubemap (always on)
-		glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
-		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	}
 
 	Context::~Context()

--- a/tests/suites/Context.cpp
+++ b/tests/suites/Context.cpp
@@ -536,7 +536,7 @@ TEST_CASE( "Context::Get return the expected values", "[context]" ) {
 		REQUIRE( GET(COPY_WRITE_BUFFER_BINDING) == 0 );
 		REQUIRE( GET(RESET_NOTIFICATION_STRATEGY) );
 		REQUIRE( GET(TEXTURE_BUFFER_BINDING) == 0 );
-		REQUIRE( GET(TEXTURE_CUBE_MAP_SEAMLESS) == true ); // Always true, since it's enabled in baregl::Context (for now)
+		REQUIRE( GET(TEXTURE_CUBE_MAP_SEAMLESS) == false );
 		REQUIRE( GET_WORKS(TIMESTAMP) );
 	});
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
This PR fixes an issue where the OpenGL context would be altered when a `baregl::Context` is created.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #55

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
